### PR TITLE
Allow multiple paragraphs in course description

### DIFF
--- a/course/course.dtx
+++ b/course/course.dtx
@@ -126,8 +126,8 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{course}[%
-    2020/10/23 %
-    v0.0.2 %
+    2021/10/23 %
+    v0.0.3 %
     Organization of course-specific metadata%
 ]
 %    \end{macrocode}
@@ -147,7 +147,9 @@
 \newcommand*{\setcourse}[1]{%
   \pgfkeys{%
     /course/.cd,%
-    description/.store in=\course@description,%
+    description/.code={
+      \long\def\course@description{##1}
+    },
     description/.value required,%
     number/.store in=\course@number,%
     number/.value required,%


### PR DESCRIPTION
This change modifies the definition of PGF keys in `\setcourse` so
that the course description can include multiple paragraphs. More
specifically, `.store in` is replaced by `.code` with `\long`
prepended to the definition.