### PR TITLE
Revert "Allow multiple paragraphs in course description"

### DIFF
--- a/course/course.dtx
+++ b/course/course.dtx
@@ -126,8 +126,8 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{course}[%
-    2021/10/23 %
-    v0.0.3 %
+    2020/10/23 %
+    v0.0.2 %
     Organization of course-specific metadata%
 ]
 %    \end{macrocode}
@@ -147,9 +147,7 @@
 \newcommand*{\setcourse}[1]{%
   \pgfkeys{%
     /course/.cd,%
-    description/.code={
-      \long\def\course@description{##1}
-    },
+    description/.store in=\course@description,%
     description/.value required,%
     number/.store in=\course@number,%
     number/.value required,%


### PR DESCRIPTION
This reverts commit b92e4fd0327037a77b33538bbc790f6652dc766d.

The aforementioned commit does not actually work because `\setcourse`
is defined using `\newcommand*`, which does not allow paragraph tokens
(see Stack Exchange answer for more details). Unfortunately, the prior
testing only used `\lipsum`, which masked the need to update the
definition of `\setcourse`.

Stack Exchange: https://tex.stackexchange.com/a/1057