### PR TITLE
Allow paragraphs in course metadata

### DIFF
--- a/course/course.dtx
+++ b/course/course.dtx
@@ -126,8 +126,8 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{course}[%
-    2020/10/23 %
-    v0.0.2 %
+    2021/10/25 %
+    v0.0.3 %
     Organization of course-specific metadata%
 ]
 %    \end{macrocode}
@@ -144,7 +144,7 @@
 % \begin{macro}{setcourse}
 % The |setcourse| macro stores the course metadata (e.g., title and description) so it can be used later.
 %    \begin{macrocode}
-\newcommand*{\setcourse}[1]{%
+\newcommand{\setcourse}[1]{%
   \pgfkeys{%
     /course/.cd,%
     description/.store in=\course@description,%
@@ -160,6 +160,9 @@
   \ignorespaces%
 }
 %    \end{macrocode}
+% \changes{0.0.3}{2021/10/25}{
+%   Allow paragraphs in course metadata
+% }
 % \end{macro}
 %
 % \begin{macro}{course}


### PR DESCRIPTION
This change uses `\newcommand` (without an `*`) to define `\setcourse`
so that the argument(s) can contain paragraph tokens.