### PR TITLE
Remove prerequisite on TeX files in subdirectories

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -56,8 +56,7 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 %.pdf: %.dtx %.sty $(DEPENDENCIES) .version.tex
 	$(compile-doc)
 
-%.pdf: %.tex $(DEPENDENCIES) $(PACKAGES) \
-       $(shell find . -mindepth 2 -name "*.tex")
+%.pdf: %.tex $(DEPENDENCIES) $(PACKAGES)
 	$(compile-doc)
 
 %.sty: directory = $(dir $<)


### PR DESCRIPTION
Large LaTeX projects often compromise multiple files, such as having a
separate file for each chapter, but assuming that a TeX document
depends upon all TeX files in subdirectories isn't always appropriate.
It is better to declare prerequisites explicitly when required to
avoid unnecessary recompilation of documents when the prior assumption
does not hold.