### PR TITLE
Correct path for prerequisites

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -48,8 +48,8 @@ external := $(basename $(shell find . -name "*.url"))
 .SECONDARY: $(external)
 
 DEPENDENCIES = $(wildcard *.bib) $(external) \
-               $(wildcard $(CWD)/include/*.bib) \
-               $(wildcard $(CWD)/include/*.tex)
+               $(wildcard $(CWD)/texmf/include/*.bib) \
+               $(wildcard $(CWD)/texmf/include/*.tex)
 
 PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 


### PR DESCRIPTION
Commit b7d45c3 moved the Makefile for TeX documents and packages, but
the path to included files (e.g., a BibTeX database) wasn't updated.
This change corrects the path for prerequisites in texmf/include/.