### PR TITLE
Add space around assignment operator

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -17,7 +17,7 @@ Makefile: ;
 TEXINPUTS := .:$(TEXINPUTS):$(CWD)/texmf//:
 
 # define TEX as pdflatex
-TEX=TEXINPUTS=$(TEXINPUTS) pdflatex -shell-escape
+TEX = TEXINPUTS=$(TEXINPUTS) pdflatex -shell-escape
 
 # Define a "Canned Recipe" for compiling PDFs from *.{dtx,tex} files.
 #


### PR DESCRIPTION
This change adds spaces around the recursively expanded TEX variable
to make it clearer that TEXINPUTS is being set for the invocation of
`pdflatex` (the multiple equals signs can be confusing).