### PR TITLE
Ensure line ends after full-width box

### DIFF
--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -18,7 +18,7 @@
 % \iffalse
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{resume}
-%<package>  [2020/03/09 v0.4.2 Style file for resume]
+%<package>  [2021/12/23 v0.4.3 Style file for resume]
 %<package>\RequirePackage{enumitem}
 %<package>\RequirePackage{microtype}
 %<package>\RequirePackage[
@@ -296,6 +296,20 @@
 % }
 % \end{macro}
 %
+% \begin{macro}{noprotrusionifhmode}
+% Define command to disable protrusion at the beginning of lines.\footnote{%
+%   Courtesy of R Schlicht: \url{https://github.com/schlcht/microtype/issues/7\#issuecomment-999923403}.
+% }
+% \texttt{\textbackslash noprotrusion} isn't used because it would add vertical space for a \texttt{parbox}.
+%    \begin{macrocode}
+\providecommand{\noprotrusionifhmode}{%
+  \ifhmode%
+    \kern-\p@\kern\p@%
+  \fi%
+}
+%    \end{macrocode}
+% \end{macro}
+%
 % \begin{macro}{thesection}
 % Overwrite \texttt{\textbackslash thesection} to remove numbers in section headers.
 %    \begin{macrocode}
@@ -467,11 +481,9 @@
 % The \texttt{makebox} command forces the information to consume an entire line.
 % This approach is better than manually breaking the line because manual line breaks add vertical space that should not always be present (e.g., when followed by a section heading).
 %    \begin{macrocode}
-  \makebox[\linewidth][l]{%
-    \hspace{0em}%  insert space to avoid weird problems with draft mode
-    \textbf{#1},
-    #2%
-  }%
+  \textbf{#1},
+  #2%
+  \newline
 %    \end{macrocode}
 %    \begin{macrocode}
 }
@@ -481,6 +493,9 @@
 % }
 % \changes{0.1.5}{2015/03/04}{
 %   Add \texttt{hspace} to avoid issues when draft mode not enabled
+% }
+% \changes{0.4.3}{2021/12/23}{
+%   Remove explicit box for institution
 % }
 % \end{macro}
 %
@@ -510,7 +525,7 @@
 % This approach is better than manually breaking the line because manual line breaks add vertical space that should not always be present (e.g., when followed by a section heading).
 %    \begin{macrocode}
   \makebox[\linewidth][l]{%
-    \hspace{0em}%  insert space to avoid weird problems with draft mode
+    \noprotrusionifhmode%
     #1%
     \hfill #2%
   }%
@@ -523,6 +538,9 @@
 % }
 % \changes{0.1.6}{2015/03/04}{
 %   Add \texttt{hspace} to avoid issues when draft mode not enabled
+% }
+% \changes{0.4.3}{2021/12/23}{
+%   Disable left protrusion to ensure box is ``full width''
 % }
 % \end{macro}
 %


### PR DESCRIPTION
The microtype packages interferes with line breaks following a
full-width box, such as those used to set the institution and position
in a resume. More specifically, the left protrusion of certain letters
causes the box to be slightly less than the total line width, and
subsequent material (e.g., another position or descriptive text)
appears on the same line, which creates an overfull hbox as the
subsequent material extends into the right margin.

This change modifies the implementation of the institution and
position macros. The institution is set without using an explicit box
(i.e., no \makebox) but with an explicit line break. Left protrusion
is disabled for the position using the newly-defined
\noprotrusionifhmode (provided by R Schlicht in a comment to a GitHub
issue). Material following an institution or position now appears on
the subsequent line.

References schlcht/microtype#7