### PR TITLE
Remove \prequestion and \postquestion macros

### DIFF
--- a/exam/exam.dtx
+++ b/exam/exam.dtx
@@ -124,12 +124,6 @@
 % produces\\
 % \input{minted/answer.out}
 %
-% The \textsf{question} environment is modified via the \textsf{prequestion} and \textsf{postquestion} macros.
-% One expected use for these macros is to number the questions---e.g., by making them part of an \textsf{enumerate} environment.
-%
-% The \textsf{prequestion} macro provides a hook to insert commands prior to the beginning of the \textsf{question} environment.
-% Users may use it to customize the \textsf{question} environment
-%
 % The \textsf{alert} macro may be used draw attention to specific text, such as negation.
 % For example,
 % \begin{VerbatimOut}[gobble=1]{minted/alert.out}
@@ -193,8 +187,8 @@
 % The spaces between the date, version, and description are significant.
 %    \begin{macrocode}
 \ProvidesPackage{exam}[%
-    2022/01/31 %
-    v0.3.1 %
+    2022/02/02 %
+    v0.4.0 %
     Style file for exams%
 ]
 %    \end{macrocode}
@@ -265,11 +259,6 @@
 % The \textsf{environ} package simplifies collecting the body of an environment for passing it to a macro.
 %    \begin{macrocode}
 \RequirePackage{environ}
-%    \end{macrocode}
-%
-% The \textsf{etoolbox} package is required to support the \textsf{prequestion} and \textsf{postquestion} hooks.
-%    \begin{macrocode}
-\RequirePackage{etoolbox}
 %    \end{macrocode}
 %
 % The \textsf{pgfkeys} package is required to support key-value arguments to macros.
@@ -373,32 +362,6 @@
   \ifexam@option@numbering%
     \end{enumerate}%
   \fi%
-}%
-%    \end{macrocode}
-%
-% \textsf{prequestion} and \textsf{postquestion} must appear before and after the environment's group to have the correct effect (e.g., when \textsf{prequestion} inserts a list \textsf{item}).
-% The \textsf{etoolbox} package provides hooks for this purpose.
-%    \begin{macrocode}
-\BeforeBeginEnvironment{question}{\prequestion}
-\AfterEndEnvironment{question}{\postquestion}
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{prequestion}
-% Define the \textsf{prequestion} macro as a hook for the \textsf{question} environment.
-%    \begin{macrocode}
-\newcommand{\prequestion}{%
-%    \end{macrocode}
-% Do nothing by default.
-%    \begin{macrocode}
-}%
-%    \end{macrocode}
-% \end{macro}
-%
-% \begin{macro}{postquestion}
-% Define the \textsf{postquestion} macro as a hook for the \textsf{question} environment.
-%    \begin{macrocode}
-\newcommand{\postquestion}{%
 %    \end{macrocode}
 % End horizontal mode to ship out the current box.
 %    \begin{macrocode}
@@ -408,6 +371,9 @@
 }%
 %    \end{macrocode}
 % \end{macro}
+% \changes{0.4.0}{2022/02/02}{
+%   Remove the pre- and post-question macros
+% }
 %
 % \begin{macro}{answer}
 % Define the \textsf{answer} environment.


### PR DESCRIPTION
The aforementioned macros are essentially hooks for the question
environment, but using LaTeX's hook management is a far more robust
approach.