### PR TITLE
exam: Correct vertical spacing for answers

### DIFF
--- a/exam/exam.dtx
+++ b/exam/exam.dtx
@@ -245,7 +245,7 @@
 % The spaces between the date, version, and description are significant.
 %    \begin{macrocode}
 \ProvidesPackage{exam}[%
-    2022/02/21 %
+    2022/02/26 %
     v0.4.0 %
     Style file for exams%
 ]
@@ -486,10 +486,6 @@
 %    \begin{macrocode}
   \setlength{\answerheight}{#1}%
 %    \end{macrocode}
-% Ensure good height for the first line.
-%    \begin{macrocode}
-  \strut%
-%    \end{macrocode}
 % Start a box.
 %    \begin{macrocode}
   \setbox0=\vbox{%
@@ -575,11 +571,11 @@
 % Typeset the answer and save it for future use.
 %    \begin{macrocode}
   \savebox{\answerbox}{%
-    \parbox{\exam@answer@width}{%
+    \parbox[t]{\exam@answer@width}{%
       \vbox{%
         % prevent vertical space when changing color (see http://goo.gl/FCfjdB)
         \leavevmode\color{answer}%
-        #2%
+        \strut #2%
       }%
     }%
   }%
@@ -612,6 +608,7 @@
     \ifexam@option@key%
       \usebox{\answerbox}%
     \else%
+      \strut%
       \exam@answer@fill%
     \fi%
   }%


### PR DESCRIPTION
This changes improves the vertical spacing of answers, specifically
ensuring the "normal" distance between the last line of the question
and first line of the answer and ensuring that the answer does not
overlap with subsequent lines.

Stack Exchange answer: https://tex.stackexchange.com/a/463739