### PR TITLE
Strip trailing whitespace from package

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -61,6 +61,8 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 %.sty: directory = $(dir $<)
 %.sty: %.ins %.dtx
 	$(TEX) -draftmode -output-directory=$(directory) $<
+# strip trailing whitespace from package
+	sed -i.bak -E 's/[[:space:]]+$$//' $@ && $(RM) $@.bak
 
 # include packages in the search path
 ifneq ($(CWD),.)  # ...but not if it will cause infinite recursion

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -65,7 +65,7 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 %.sty: %.ins %.dtx
 	$(TEX) -draftmode -output-directory=$(directory) $<
 # strip trailing whitespace from package
-	sed -i.bak -E 's/[[:space:]]+$$//' $@ && $(RM) $@.bak
+	cd $(directory); sed -i.bak -E 's/[[:space:]]+$$//' $@ && $(RM) $@.bak
 
 # include packages in the search path
 ifneq ($(CWD),.)  # ...but not if it will cause infinite recursion


### PR DESCRIPTION
When a preamble (or postamble) is included in a package, DocStrip
prepends \MetaPrefix ("%% " by default) to each line. Thus, a blank
line in the preamble (postamble) ends with a space.

Although packages are not committed to version control in this
repository, they must be when shared (i.e., used elsewhere), and
commands like `git diff --check` warn about trailing whitespace.
Consequently, this change strips any trailing whitespace -- not
limited to just that introduced by DocStrip -- from the generated
package.

Stack Exchange: https://tex.stackexchange.com/a/470230