### PR TITLE
Only mark external files as secondary targets

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -44,7 +44,10 @@ done
 endef
 
 external := $(basename $(shell find . -name "*.url"))
+ifneq ($(external),)  # .SECONDARY should have prerequisite(s)
+# do not automatically delete external files
 .SECONDARY: $(external)
+endif
 
 DEPENDENCIES = $(wildcard *.bib) $(external) \
                $(wildcard $(CWD)/texmf/include/*.bib) \


### PR DESCRIPTION
External files (i.e., those fetched on-demand) are not deleted
automatically because they are expected to be used again. This change
guards the declaration of the .SECONDARY target so any external files
are its prerequisites. Otherwise, all targets are treated as secondary
targets, and no target is removed even when it is an intermediate.