### PR TITLE
Avoid unnecessary `pdflatex` invocations

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -26,15 +26,15 @@ TEX = TEXINPUTS=$(TEXINPUTS) pdflatex -shell-escape
 #       it to be '='.
 define compile-doc
 @$(RM) $*.sta
-$(TEX) -draftmode $<
+$(TEX) $<
 if grep -E '^\\@istfilename' $*.aux; then \
-		makeglossaries -d $(*D) $(*F) && $(TEX) -draftmode $<; \
+		makeglossaries -d $(*D) $(*F) && $(TEX) $<; \
 fi
 files=$$(sed -n 's/\\@input{\(.*\)}/\1/p' $*.aux); \
 		if grep --quiet -E '\\(citation)' $*.aux $$files; then \
 			BIBINPUTS=$(TEXINPUTS) bibtex $*; \
 		fi
-$(TEX) -draftmode $<
+$(TEX) $<
 if [ -f $*.idx ]; then makeindex $$(if [[ $< == *.dtx ]]; then echo -s gind.ist; fi) -o $*.ind $*.idx; fi
 if [ -f $*.glo ]; then makeindex -s $$(if [[ $< == *.dtx ]]; then echo gglo; else echo $*; fi).ist -o $*.gls $*.glo; fi
 $(TEX) $<
@@ -63,7 +63,7 @@ PACKAGES = $(wildcard *.cls) $(wildcard *.sty)
 
 %.sty: directory = $(dir $<)
 %.sty: %.ins %.dtx
-	$(TEX) -draftmode -output-directory=$(directory) $<
+	$(TEX) -output-directory=$(directory) $<
 # strip trailing whitespace from package
 	cd $(directory); sed -i.bak -E 's/[[:space:]]+$$//' $@ && $(RM) $@.bak
 

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -32,12 +32,10 @@ if grep -E '^\\@istfilename' $*.aux; then \
 fi
 files=$$(sed -n 's/\\@input{\(.*\)}/\1/p' $*.aux); \
 		if grep --quiet -E '\\(citation)' $*.aux $$files; then \
-			BIBINPUTS=$(TEXINPUTS) bibtex $*; \
+			BIBINPUTS=$(TEXINPUTS) bibtex $* && $(TEX) $<; \
 		fi
-$(TEX) $<
-if [ -f $*.idx ]; then makeindex $$(if [[ $< == *.dtx ]]; then echo -s gind.ist; fi) -o $*.ind $*.idx; fi
-if [ -f $*.glo ]; then makeindex -s $$(if [[ $< == *.dtx ]]; then echo gglo; else echo $*; fi).ist -o $*.gls $*.glo; fi
-$(TEX) $<
+if [ -f $*.idx ]; then makeindex $$(if [[ $< == *.dtx ]]; then echo -s gind.ist; fi) -o $*.ind $*.idx && $(TEX) $<; fi
+if [ -f $*.glo ]; then makeindex -s $$(if [[ $< == *.dtx ]]; then echo gglo; else echo $*; fi).ist -o $*.gls $*.glo && $(TEX) $<; fi
 while ( grep -q '^LaTeX Warning: Label(s) may have changed' $*.log ) do \
     $(TEX) $<; \
 done


### PR DESCRIPTION
For simple LaTeX documents (e.g., those without any references such as
a standalone image), `pdflatex` is executed three times, which is
unnecessary. This change guards the invocation of `pdflatex` after
`bibtex` and `makeindex` to avoid the unnecessary compilations.

This change sacrifices some efficiency in the case of "complex"
documents with citations, glossaries, and indices because `pdflatex`
need not be run after every auxiliary tool (e.g., `makeindex`).
Nevertheless, the increased compilation time is less likely to be
noticed in the case of such documents.

Closes https://github.com/joel-coffman/latex-incubator/issues/46