### PR TITLE
Add default target to Makefile.tex

### DIFF
--- a/anonymous/Makefile
+++ b/anonymous/Makefile
@@ -1,21 +1,6 @@
-# use Bash as the shell when interpreting the Makefile
-SHELL := /bin/bash
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
-
-examples:
+minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(documentation): email.sty hyperfix.sty minted-doc.sty | examples
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
+$(documentation): | minted

--- a/anonymous/Makefile
+++ b/anonymous/Makefile
@@ -3,4 +3,4 @@ include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(documentation): | minted
+$(documentation): email.sty hyperfix.sty minted-doc.sty | minted

--- a/anonymous/Makefile
+++ b/anonymous/Makefile
@@ -1,6 +1,6 @@
 include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
-minted:
+examples:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(documentation): email.sty hyperfix.sty minted-doc.sty | minted
+$(documentation): email.sty hyperfix.sty minted-doc.sty | examples

--- a/beamer/themes/outer/logo/Makefile
+++ b/beamer/themes/outer/logo/Makefile
@@ -1,22 +1,9 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): example.pdf
 $(documentation): email.sty hyperfix.sty minted-doc.sty theme-doc.sty | minted
 
 example.pdf: beamerouterthemelogo.sty
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/course/Makefile
+++ b/course/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/editing/Makefile
+++ b/editing/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty minted-doc.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/email/Makefile
+++ b/email/Makefile
@@ -1,19 +1,7 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
 $(packages): hyperfix.sty
 $(documentation): minted-doc.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/exam/Makefile
+++ b/exam/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty minted-doc.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/hyperfix/Makefile
+++ b/hyperfix/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty minted-doc.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/manyauth/Makefile
+++ b/manyauth/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/minted-doc/Makefile
+++ b/minted-doc/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/resume/Makefile
+++ b/resume/Makefile
@@ -1,19 +1,7 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
 $(packages): hyperfix.sty
 $(documentation): email.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/schedule/Makefile
+++ b/schedule/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/slides/Makefile
+++ b/slides/Makefile
@@ -1,16 +1,3 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
-
-$(packages):
-$(documentation): email.sty theme-doc.sty
-
 include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
+
+$(documentation): email.sty theme-doc.sty

--- a/subtitle/Makefile
+++ b/subtitle/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty minted-doc.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/syllabus/Makefile
+++ b/syllabus/Makefile
@@ -1,21 +1,8 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty minted-doc.sty | minted
 
 derivatives += syllabus.sty whiting.logo.small.horizontal.black.eps
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -4,7 +4,7 @@ documentation ?= $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
 
 documents ?= $(documentation) \
              $(patsubst %.tex,%.pdf,\
-                        $(filter-out $(wildcard *.code.tex),$(wildcard *.tex)))
+                        $(filter-out $(wildcard tikzlibrary*.code.tex),$(wildcard *.tex)))
 
 .PHONY: all
 all: packages documents

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -1,9 +1,9 @@
 # vim: syntax=make
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
+packages ?= $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
+documentation ?= $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
 
-documents = $(documentation) \
-            $(patsubst %.tex,%.pdf,$(wildcard *.tex))
+documents ?= $(documentation) \
+             $(patsubst %.tex,%.pdf,$(wildcard *.tex))
 
 .PHONY: all
 all: packages documents

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -1,4 +1,16 @@
 # vim: syntax=make
+packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
+documents = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx)) \
+            $(patsubst %.tex,%.pdf,$(wildcard *.tex))
+
+.PHONY: all
+all: packages documents
+
+.PHONY: packages
+packages: $(packages)
+
+.PHONY: documents
+documents: $(documents) $(packages)
 
 # use Bash as the shell when interpreting the Makefile
 SHELL := /bin/bash

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -3,7 +3,8 @@ packages ?= $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
 documentation ?= $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
 
 documents ?= $(documentation) \
-             $(patsubst %.tex,%.pdf,$(wildcard *.tex))
+             $(patsubst %.tex,%.pdf,\
+                        $(filter-out $(wildcard *.code.tex),$(wildcard *.tex)))
 
 .PHONY: all
 all: packages documents

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -1,6 +1,8 @@
 # vim: syntax=make
 packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documents = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx)) \
+documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
+
+documents = $(documentation) \
             $(patsubst %.tex,%.pdf,$(wildcard *.tex))
 
 .PHONY: all

--- a/theme-doc/Makefile
+++ b/theme-doc/Makefile
@@ -1,19 +1,6 @@
-.PHONY: all
-all: packages documentation
-
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 minted:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(packages):
 $(documentation): email.sty minted-doc.sty | minted
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/visualization/Makefile
+++ b/visualization/Makefile
@@ -1,24 +1,15 @@
-# use Bash as the shell when interpreting the Makefile
-SHELL := /bin/bash
+documentation := $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
 
-.PHONY: all
-all: packages documentation
+documents := $(documentation) \
+             $(patsubst %.tex,%.pdf,\
+                        $(filter-out $(wildcard *.code.tex),$(wildcard *.tex)))
 
-packages = $(patsubst %.dtx,%.sty,$(wildcard *.dtx))
-documentation = $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-.PHONY: packages
-packages: $(packages)
-
-.PHONY: documentation
-documentation: $(documentation)
+include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 examples:
 	if ! [ -d $@ ]; then mkdir --parents $@; fi
 
-$(documentation): $(packages) | examples
+$(documentation): | examples
 
 derivatives += $(patsubst %.dtx,%.sty,$(wildcard *.dtx)) \
                tikzlibrarypgfplots.*.code.tex
-
-include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex

--- a/visualization/Makefile
+++ b/visualization/Makefile
@@ -1,9 +1,3 @@
-documentation := $(patsubst %.dtx,%.pdf,$(wildcard *.dtx))
-
-documents := $(documentation) \
-             $(patsubst %.tex,%.pdf,\
-                        $(filter-out $(wildcard *.code.tex),$(wildcard *.tex)))
-
 include $(shell git rev-parse --show-toplevel)/texmf/Makefile.tex
 
 examples:


### PR DESCRIPTION
This change adds a default target to Makefile.tex so that Makefiles
that include Makefile.tex need not specify any target explicitly.