### PR TITLE
Allow targets to be specified to root Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,13 @@ $(packages):
 	$(MAKE) -C $@ dist distcheck
 
 
+targets = $(filter-out $(packages) list,$(MAKECMDGOALS))
+
+.PHONY: $(targets)
+$(targets):
+	@for package in $(packages); do $(MAKE) -C $$package $@; done
+
+
 .PHONY: list
 list:
 	@for package in $(packages); do echo $$package; done

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -90,7 +90,7 @@ vpath %.dtx $(CWD):$(addprefix $(CWD)/,$(packages))
 vpath %.sty $(CWD):$(addprefix $(CWD)/,$(packages))
 
 
-derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.sta *.toc *.vrb .version.tex
+derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.sta *.toc *.vrb
 
 .PHONY: mostlyclean
 mostlyclean:

--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -74,7 +74,7 @@ vpath %.dtx $(CWD):$(addprefix $(CWD)/,$(packages))
 vpath %.sty $(CWD):$(addprefix $(CWD)/,$(packages))
 
 
-derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.sta *.toc *.vrb
+derivatives += *.acn *.acr *.alg *.aux *.bbl *.blg *.dvi *.glb *.glx *.glg *.glo *.gls *.idx *.ind *.ilg *.ist *.log *.lof *.lot *.nav *.out *.pyg *.snm *.sta *.toc *.vrb .version.tex
 
 .PHONY: mostlyclean
 mostlyclean:


### PR DESCRIPTION
This change passes any goals that don't match the directory of a
package to a recursive invocation of `make` when building all the
packages. In essence, it allows standard targets (e.g., clean or dist)
to be used when building each package.