### PR TITLE
Add script to identify dependencies

### DIFF
--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 set -u

--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+
+set -e
+set -u
+set -x
+
+
+docker run --rm debian:latest /bin/bash -c "
+set -x
+
+apt update
+apt install --no-install-recommends --yes apt-file
+
+apt-file update
+for file in $*; do
+  apt-file search "\$file"
+done
+"

--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -5,14 +5,14 @@ set -u
 set -x
 
 
-docker run --interactive --rm debian:latest /bin/bash <<SCRIPT
-set -x
+docker run --interactive --rm debian:latest /bin/bash <<-SCRIPT
+	set -x
 
-apt update --quiet
-apt install --no-install-recommends --quiet --yes apt-file
+	apt update --quiet
+	apt install --no-install-recommends --quiet --yes apt-file
 
-apt-file update
-for file in $*; do
-  apt-file search "\$file"
-done
+	apt-file update
+	for file in $*; do
+	  apt-file search "\$file"
+	done
 SCRIPT

--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -5,7 +5,7 @@ set -u
 set -x
 
 
-docker run --rm debian:latest /bin/bash -c "
+docker run --interactive --rm debian:latest /bin/bash <<SCRIPT
 set -x
 
 apt update
@@ -15,4 +15,4 @@ apt-file update
 for file in $*; do
   apt-file search "\$file"
 done
-"
+SCRIPT

--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -2,9 +2,16 @@
 
 set -e
 set -u
+
+
+# print help message if executed without arguments
+if [ $# -lt 1 ]; then
+  echo "Usage: $(basename "$0") file [...]"
+  exit
+fi
+
+# search latest Debian image for file(s)
 set -x
-
-
 docker run --interactive --rm debian:latest /bin/bash <<-SCRIPT
 	set -x
 

--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -19,7 +19,7 @@ docker run --interactive --rm debian:latest /bin/bash <<-SCRIPT
 	apt install --no-install-recommends --quiet --yes apt-file
 
 	apt-file update
-	for file in $*; do
+	for file in "$@"; do
 	  apt-file search "\$file"
 	done
 SCRIPT

--- a/texmf/scripts/identify-package.sh
+++ b/texmf/scripts/identify-package.sh
@@ -8,8 +8,8 @@ set -x
 docker run --interactive --rm debian:latest /bin/bash <<SCRIPT
 set -x
 
-apt update
-apt install --no-install-recommends --yes apt-file
+apt update --quiet
+apt install --no-install-recommends --quiet --yes apt-file
 
 apt-file update
 for file in $*; do


### PR DESCRIPTION
Identifying package dependencies can be difficult because LaTeX
packages are distributed as part of larger TeX Live packages in
Debian. This script uses `apt-file` to identify the specific Debian
package(s) that provide a file.