### PR TITLE
resume: Use enumitem to control list spacing

### DIFF
--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -18,7 +18,7 @@
 % \iffalse
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{resume}
-%<package>  [2022/05/02 v0.4.5 Style file for resume]
+%<package>  [2022/05/02 v0.4.6 Style file for resume]
 %<package>\RequirePackage{enumitem}
 %<package>\RequirePackage{microtype}
 %<package>\RequirePackage[
@@ -260,6 +260,15 @@
 % \changes{0.4.5}{2022/05/02}{
 %   Use \texttt{parskip} instead of \texttt{baselineskip} around lists
 % }
+% A top-level list should have additional vertical space after it, mimicking the additional space between paragraphs introduced by the \textsf{parskip} package.
+%    \begin{macrocode}
+\setlist[1]{
+  after={\vspace{\resume@old@parskip}},
+}
+%    \end{macrocode}
+% \changes{0.4.6}{2022/05/02}{
+%   Add space after lists to match vertical space between paragraphs
+% }
 %
 % \changes{0.1.3}{2015/02/10}{
 %   Use smaller bullet symbol for first-level itemize environment
@@ -270,16 +279,11 @@
 % \end{macro}
 %
 % \begin{macro}{endlist}
-% Save |endlist| macro and redefine it with additional vertical space to match expected output from \textsf{parskip} package.
-%    \begin{macrocode}
-\let\resume@old@endlist=\endlist\relax
-\def\endlist{%
-  \resume@old@endlist%
-  \vspace{\resume@old@parskip}%
-}
-%    \end{macrocode}
 % \changes{0.1.3}{2015/02/10}{
 %   Add vertical spacing after list to compensate for negative spacing in setlist
+% }
+% \changes{0.4.6}{2022/05/02}{
+%   Do not redefine \texttt{endlist} macro
 % }
 % \end{macro}
 %
@@ -608,11 +612,12 @@
   }{%
       \usecounter{c@publication}
       \setcounter{c@publication}{\value{c@reference}}%
-      \setlength{\topsep}{0ex}%
+      \setlength{\topsep}{-\resume@old@parskip}%
   }%
 }{%
   \setcounter{c@reference}{\value{c@publication}}%
   \end{list}%
+  \addvspace{\resume@old@parskip}%
 }
 %    \end{macrocode}
 % \end{macro}


### PR DESCRIPTION
This change removes the redefinition of \endlist in favor of using
enumitem to manage the vertical space around (particularly after
top-level) lists. In addition, it modifies the vertical spacing for
publications to match other lists.