### PR TITLE
resume: Fix vertical space after nested lists

### DIFF
--- a/resume/example.tex
+++ b/resume/example.tex
@@ -52,7 +52,11 @@
   \end{itemize}
 
   \item Achievement
+  \begin{itemize}
+    \item Sub-achievement
+  \end{itemize}
 \end{itemize}
+\lipsum[1][5-9]
 
 \position{Position}{Year(s)}
 \begin{itemize}
@@ -62,7 +66,7 @@
 
 \institution{Employer}{City, State}
 \position{Position}{Year(s)}
-\lipsum[1][5-9]
+\lipsum[2][1-4]
 
 %------------------------------------------------------------------------------
 \section{Skills} %-------------------------------------------------------------

--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -250,8 +250,7 @@
 % Remove all vertical spacing between items and paragraphs as well as extra whitespace from \textsf{parskip} package.
 %    \begin{macrocode}
 \setlist{
-  noitemsep,
-  topsep=-\resume@old@parskip,
+  nosep,
 }
 %    \end{macrocode}
 % \changes{0.1.3}{2015/02/10}{
@@ -263,11 +262,15 @@
 % A top-level list should have additional vertical space after it, mimicking the additional space between paragraphs introduced by the \textsf{parskip} package.
 %    \begin{macrocode}
 \setlist[1]{
-  after={\vspace{\resume@old@parskip}},
+  after={\vspace*{\resume@old@parskip}},
+  before={\addtolength{\topsep}{-\resume@old@parskip}},
 }
 %    \end{macrocode}
 % \changes{0.4.6}{2022/05/02}{
 %   Add space after lists to match vertical space between paragraphs
+% }
+% \changes{0.4.7}{2022/05/03}{
+%   Correct vertical space after nested lists
 % }
 %
 % \changes{0.1.3}{2015/02/10}{

--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -18,7 +18,7 @@
 % \iffalse
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{resume}
-%<package>  [2022/05/03 v0.4.6 Style file for resume]
+%<package>  [2022/05/03 v0.4.7 Style file for resume]
 %<package>\RequirePackage{enumitem}
 %<package>\RequirePackage{microtype}
 %<package>\RequirePackage[


### PR DESCRIPTION
This change corrects the vertical space after nested lists. More
specifically, it ensures that the vertical space is consistent
regardless of the depth of the list that immediately precedes it.