### PR TITLE
resume: Ignore spaces after \position

### DIFF
--- a/resume/example.tex
+++ b/resume/example.tex
@@ -31,6 +31,7 @@
 
 \institution{Institution}{City, State}
 \degree{Degree}{Year}
+\degree{Degree}{Year}
 
 \institution{Institution}{City, State}
 \degree{Degree}{Year}

--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -18,7 +18,7 @@
 % \iffalse
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{resume}
-%<package>  [2022/05/03 v0.4.7 Style file for resume]
+%<package>  [2022/05/04 v0.4.7 Style file for resume]
 %<package>\RequirePackage{enumitem}
 %<package>\RequirePackage{microtype}
 %<package>\RequirePackage[
@@ -567,7 +567,11 @@
     \noprotrusionifhmode%
     #1%
     \hfill #2%
-  }%
+  }\hfill%
+%    \end{macrocode}
+% Ignore subsequent space, which might introduce a pargraph skip (e.g., when the position is used in an |\item|).
+%    \begin{macrocode}
+  \ignorespaces
 %    \end{macrocode}
 %    \begin{macrocode}
 }
@@ -583,6 +587,9 @@
 % }
 % \changes{0.4.6}{2022/05/03}{
 %   Remove following paragraph skip (if exists)
+% }
+% \changes{0.4.7}{2022/05/04}{
+%   Ignore subsequent space, which might introduce paragraph skip
 % }
 % \end{macro}
 %

--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -567,11 +567,7 @@
     \noprotrusionifhmode%
     #1%
     \hfill #2%
-  }\nopagebreak
-%    \end{macrocode}
-% Remove any pargraph skip (e.g., when the position is used in an |\item|).
-%    \begin{macrocode}
-  \vskip-\parskip
+  }%
 %    \end{macrocode}
 %    \begin{macrocode}
 }


### PR DESCRIPTION
Commit 792047a removed a paragraph skip after \position to avoid
extraneous whitespace when the position appeared in a list, but
removing the fixed space prevented a (normal) paragraph skip when the
position was followed by a paragraph break.

This change modifies the implementation of \position so it ignores
subsequent spaces, which addresses the original problem and preserves
any (normal) skip between paragraphs.