### PR TITLE
resume: Do not redefine \abstractname

### DIFF
--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -18,7 +18,7 @@
 % \iffalse
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{resume}
-%<package>  [2022/05/04 v0.4.8 Style file for resume]
+%<package>  [2022/06/07 v0.4.8 Style file for resume]
 %<package>\RequirePackage{enumitem}
 %<package>\RequirePackage{microtype}
 %<package>\RequirePackage[
@@ -311,13 +311,6 @@
 % \changes{0.4.8}{2022/05/04}{
 %   Redefine the abstract environment
 % }
-% \end{macro}
-%
-% \begin{macro}{abstractname}
-%   Overwrite \textbackslash abstractname so it does not appear.
-%    \begin{macrocode}
-\let\abstractname=\relax
-%    \end{macrocode}
 % \end{macro}
 %
 % \begin{macro}{maketitle}


### PR DESCRIPTION
Commit 152979c redefines the abstract environment. Consequently, it is
no longer necessary to redefine \abstractname so that "Abstract" does
not appear.