### PR TITLE
minted-doc: Correct entry in change history

### DIFF
--- a/minted-doc/minted-doc.dtx
+++ b/minted-doc/minted-doc.dtx
@@ -156,7 +156,7 @@
 }
 %    \end{macrocode}
 % \changes{0.1.1}{2017/07/13}{%
-%   Do not indent after |\inputminted|
+%   Do not indent after \textbackslash inputminted
 % }
 %
 % \subsection{Macros}


### PR DESCRIPTION
The v0.1.1 entry in the change history was omitted due to the
inclusion of verbatim content.