### PR TITLE
Relax search pattern for additional LaTeX runs

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -51,7 +51,7 @@ files=$$(sed -n 's/\\@input{\(.*\)}/\1/p' $*.aux); \
 		fi
 if [ -f $*.idx ]; then makeindex $$(if [[ $< == *.dtx ]]; then echo -s gind.ist; fi) -o $*.ind $*.idx && $(TEX) $<; fi
 if [ -f $*.glo ]; then makeindex -s $$(if [[ $< == *.dtx ]]; then echo gglo; else echo $*; fi).ist -o $*.gls $*.glo && $(TEX) $<; fi
-while ( grep -q '^LaTeX Warning: Label(s) may have changed' $*.log ) do \
+while ( grep -E -q 'Warning: .* (has|have) changed.' $*.log ) do \
     $(TEX) $<; \
 done
 endef


### PR DESCRIPTION
Any of the following messages in a log file indicates that additional
LaTeX runs are necessary:

* LaTeX Warning: Label(s) may have changed. Rerun to get
  cross-references right.
* Package standalone Warning: Sub-preamble of file '\<path>' has
  changed. Content will be ignored. Please rerun LaTeX!
* Package rerunfilecheck Warning: File '\<filename>' has changed.
  (rerunfilecheck)                Rerun to get outlines right
  (rerunfilecheck)                or use package 'bookmark'.

Unfortunately, the output is not standardized across packages which
makes heuristics for determining if another compilation pass is
necessary a best effort.

Stack Exchange: https://tex.stackexchange.com/a/265746

Fixes #66