### PR TITLE
Mark repository as safe after checkout

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -28,6 +28,9 @@ jobs:
               ca-certificates \
               git
       - uses: actions/checkout@v2
+      - name: Configure Git
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install dependencies
         run: |
           apt update && apt install --no-install-recommends --yes \


### PR DESCRIPTION
Git 2.35.2 stops directory traversals when ownership changes from the current user (in response to CVE-2022-24765). Consequently, executing `git` fails in GitHub Actions for Debian Buster, which runs as a container within Ubuntu, because the user context changes after checking out the repository.

This change follows the checkout action's recommended workaround of marking the repository ($GITHUB_WORKSPACE) as safe.

References

- actions/checkout#766
- actions/runner#2033