### PR TITLE
Remove Git installation in make job

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -22,11 +22,6 @@ jobs:
         run: |
           apt update && apt install --no-install-recommends --yes \
               lsb-release
-      - name: Install Git
-        run: |
-          apt update && apt install --no-install-recommends --yes \
-              ca-certificates \
-              git
       - uses: actions/checkout@v2
       - name: Configure Git
         run: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -23,15 +23,15 @@ jobs:
           apt update && apt install --no-install-recommends --yes \
               lsb-release
       - uses: actions/checkout@v2
-      - name: Configure Git
-        run: |
-          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: Install dependencies
         run: |
           apt update && apt install --no-install-recommends --yes \
               $(cat .ci/build/make/dependencies/$(lsb_release -cs)/apt.list)
           pip3 install --requirement \
               .ci/build/make/dependencies/$(lsb_release -cs)/python.list
+      - name: Configure Git
+        run: |
+          git config --global --add safe.directory "$GITHUB_WORKSPACE"
       - name: make
         run: make --jobs=$(nproc) --output-sync
       - name: Archive artifacts


### PR DESCRIPTION
Git is already listed as a dependency. Thus, it is installed in the "Install dependencies" step of the job.