### PR TITLE
Avoid linebreaks in TeX's console output

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -27,12 +27,13 @@ CWD != realpath $(CWD)/.. --relative-to=$(CURDIR)
 # empty recipes to avoid rebuilding Makefiles via implicit rules
 Makefile: ;
 
-# add texmf directory to TEXINPUTS environment variable to find included files
-# (e.g., packages)
+# add texmf directory to TEXMFCNF and TEXINPUTS environment variables to find
+# TeX configuration and included files (e.g., packages)
+TEXMFCNF := $(CWD)/texmf/:
 TEXINPUTS := .:$(TEXINPUTS):$(CWD)/texmf//:
 
 # define TEX as pdflatex
-TEX = TEXINPUTS=$(TEXINPUTS) pdflatex -shell-escape
+TEX = TEXMFCNF=$(TEXMFCNF) TEXINPUTS=$(TEXINPUTS) pdflatex -shell-escape
 
 # Define a "Canned Recipe" for compiling PDFs from *.{dtx,tex} files.
 #

--- a/texmf/texmf.cnf
+++ b/texmf/texmf.cnf
@@ -1,0 +1,3 @@
+max_print_line = 10000
+error_line = 254
+half_error_line = 238


### PR DESCRIPTION
This change prevents TeX from wrapping lines after 79 characters (the default). More specifically, it increases the maximum line length to 10000 characters as well as increasing the length of error lines in the output.

The configuration changes appear in a "local" TeX configuration file so that the invocation of TeX remains as simple as possible.

References:
- Avoiding linebreaks in LaTeX console / log output: https://tex.stackexchange.com/a/52994
- texlive: Personal "texmf.cnf": https://tex.stackexchange.com/a/410610