### PR TITLE
Simplify commands by exporting variables

### DIFF
--- a/texmf/Makefile.tex
+++ b/texmf/Makefile.tex
@@ -29,11 +29,13 @@ Makefile: ;
 
 # add texmf directory to TEXMFCNF and TEXINPUTS environment variables to find
 # TeX configuration and included files (e.g., packages)
-TEXMFCNF := $(CWD)/texmf/:
-TEXINPUTS := .:$(TEXINPUTS):$(CWD)/texmf//:
+export TEXMFCNF := $(CWD)/texmf/:
+export TEXINPUTS := .:$(TEXINPUTS):$(CWD)/texmf//:
+
+export BIBINPUTS := $(TEXINPUTS)
 
 # define TEX as pdflatex
-TEX = TEXMFCNF=$(TEXMFCNF) TEXINPUTS=$(TEXINPUTS) pdflatex -shell-escape
+TEX = pdflatex -shell-escape
 
 # Define a "Canned Recipe" for compiling PDFs from *.{dtx,tex} files.
 #
@@ -48,7 +50,7 @@ if grep -E '^\\@istfilename' $*.aux; then \
 fi
 files=$$(sed -n 's/\\@input{\(.*\)}/\1/p' $*.aux); \
 		if grep --quiet -E '\\(citation)' $*.aux $$files; then \
-			BIBINPUTS=$(TEXINPUTS) bibtex $* && $(TEX) $<; \
+			bibtex $* && $(TEX) $<; \
 		fi
 if [ -f $*.idx ]; then makeindex $$(if [[ $< == *.dtx ]]; then echo -s gind.ist; fi) -o $*.ind $*.idx && $(TEX) $<; fi
 if [ -f $*.glo ]; then makeindex -s $$(if [[ $< == *.dtx ]]; then echo gglo; else echo $*; fi).ist -o $*.gls $*.glo && $(TEX) $<; fi


### PR DESCRIPTION
This change simplifies the invocations of `pdflatex` and `bibtex` by exporting various variables to the environment.