### PR TITLE
visualization: Label x axis for Likert graphs

### DIFF
--- a/visualization/visualization.dtx
+++ b/visualization/visualization.dtx
@@ -282,6 +282,7 @@
 % \begin{tikzpicture}
 %   \begin{axis}[
 %       likert=5,
+%       explicit axis labels={Disagree}{Agree},
 %       symbolic y coords={Post,Pre},
 %       width=\linewidth - 35pt,
 %       ytick=data,
@@ -339,8 +340,8 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{visualization}[%
-    2022/07/28 %
-    v0.1.1 %
+    2023/07/13 %
+    v0.1.2 %
     Data visualization library%
 ]
 %    \end{macrocode}
@@ -477,6 +478,33 @@
     },
     bar width=\baselineskip,
     enlarge y limits={abs=\baselineskip},
+    explicit axis labels/.style 2 args={
+      axis line style={stealth-stealth},
+      after end axis/.append code={
+        \begin{scope}[
+          every node/.style={
+            execute at end node=\strut,
+            fill=white,
+            fill opacity=0.75,
+            font=\smaller,
+            inner sep=1pt,
+            text opacity=0.50,
+          },
+        ]
+          \node[
+              anchor=west,
+              xshift=0.75em,
+          ] at (axis description cs:0,0) {##1};
+          \node[
+              anchor=east,
+              xshift=-0.75em,
+          ] at (axis description cs:1,0) {##2};
+        \end{scope}
+      },
+      xtick={1.00},
+      xticklabels={},
+    },
+    explicit axis labels/.default={Disagree}{Agree},
     label style={
       font=\smaller,
     },
@@ -492,7 +520,7 @@
     xmin=0.00,
     xmax=2.00,
     xtick={0.00,0.50,1.00,1.50,2.00},
-    xticklabels={$-100\%$,$-50\%$,$0\%$,$+50\%$,$+100\%$},
+    xticklabels={$100\%$,$50\%$,$0\%$,$50\%$,$100\%$},
     x tick label style={
       text opacity=0.5,
     },
@@ -510,6 +538,9 @@
   },
 }
 %    \end{macrocode}
+% \changes{0.1.2}{2023/07/13}{
+%    Label x axis for Likert visualization
+% }
 %
 % \iffalse
 %</tikzlibrarypgfplots.categorical.code.tex>


### PR DESCRIPTION
Reviewers have commented negatively about the axis labels for the Likert visualization, stating that the negative percentages (e.g., to indicate disagreement) aren't intuitive. This change adds a new style, `explicit axis labels`, for use when a legend cannot be included: the tick mark labels on the x axis are omitted in favor of labeling the right and left extents (as "Disagree" and "Agree" respectively).

Regardless of whether the aforementioned style is used, the negative and positive signs on the x axis tick mark labels are removed.