### PR TITLE
slides: Avoid numbering frames when not necessary

### DIFF
--- a/slides/slides.dtx
+++ b/slides/slides.dtx
@@ -22,7 +22,7 @@
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{slides}
 %<*package>
-  [2023/05/09 v0.5.1 Slides package for presentations]
+  [2024/05/01 v0.5.2 Slides package for presentations]
 %</package>
 %<package>\RequirePackage{xcolor}
 %<package>\RequirePackage{xpatch}

--- a/slides/slides.dtx
+++ b/slides/slides.dtx
@@ -287,6 +287,18 @@
 % }
 %
 % \subsection{Templates}
+% When |allowframebreaks| is used, only include the number (I, II, III, etc.) when the content requires more than one frame.
+%    \begin{macrocode}
+\detbeamertemplate*{frametitle continuation}{only if multiple}{%
+  \ifnum\numexpr\beamer@endpageofframe+1-\beamer@startpageofframe\relax>1
+    \insertcontinuationcountroman
+  \fi%
+}
+%    \end{macrocode}
+% \changes{0.5.2}{2024/05/01}{
+%   Do not number frames with automatic breaks when there is a single frame
+% }
+%
 % Remove navigation symbols at the bottom of slides.
 % The navigation symbols are almost too small to see in many cases and rarely used in practice.
 %    \begin{macrocode}


### PR DESCRIPTION
This change redefines Beamer's `frametitle continuation` template, which is used by the `allowframebreaks` option, to include the number (I, II, III, etc.) only when the content requires more than one frame.