### PR TITLE
resume: Discard after list space at page start

### DIFF
--- a/resume/resume.dtx
+++ b/resume/resume.dtx
@@ -18,7 +18,7 @@
 % \iffalse
 %<package>\NeedsTeXFormat{LaTeX2e}
 %<package>\ProvidesPackage{resume}
-%<package>  [2022/06/07 v0.4.8 Style file for resume]
+%<package>  [2025/01/29 v0.4.9 Style file for resume]
 %<package>\RequirePackage{enumitem}
 %<package>\RequirePackage{microtype}
 %<package>\RequirePackage[
@@ -263,7 +263,7 @@
 % A top-level list should have additional vertical space after it, mimicking the additional space between paragraphs introduced by the \textsf{parskip} package.
 %    \begin{macrocode}
 \setlist[1]{
-  after={\vspace*{\resume@old@parskip}},
+  after={\vspace{\resume@old@parskip}},
   before={\addtolength{\topsep}{-\resume@old@parskip}},
 }
 %    \end{macrocode}
@@ -272,6 +272,9 @@
 % }
 % \changes{0.4.7}{2022/05/03}{
 %   Correct vertical space after nested lists
+% }
+% \changes{0.4.9}{2025/01/29}{
+%   Remove vertical space after page break
 % }
 %
 % \changes{0.1.3}{2015/02/10}{


### PR DESCRIPTION
This change replaces `\vspace*` with `\vspace` so that the space after a list is discarded if would appear at the start (i.e., top) of a page.