### PR TITLE
Use actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -42,6 +42,6 @@ jobs:
       - name: Archive artifacts
         uses: actions/upload-artifact@v4
         with:
-          name: packages
+          name: packages-${{ matrix.os }}
           path: |
             **/*.zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,7 +40,7 @@ jobs:
       - name: make
         run: make --jobs=$(nproc) --output-sync
       - name: Archive artifacts
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: packages
           path: |

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -40,8 +40,9 @@ jobs:
       - name: make
         run: make --jobs=$(nproc) --output-sync
       - name: Archive artifacts
+        if: ${{ matrix.os == 'debian:bullseye' }}
         uses: actions/upload-artifact@v4
         with:
-          name: packages-${{ matrix.os }}
+          name: packages
           path: |
             **/*.zip


### PR DESCRIPTION
actions/upload-artifact@v2 was deprecated on 30 June 2024, and the GitHub Actions workflow using it is failing with the following error message:

> This request has been automatically failed because it uses a deprecated version of actions/upload-artifact: v2

Thus, this change updates the version of actions/upload-artifact.

@actions/upload-artifact: https://github.com/actions/upload-artifact