### PR TITLE
Include Debian Bookworm in CI configuration

### DIFF
--- a/.ci/build/make/dependencies/bookworm/apt.list
+++ b/.ci/build/make/dependencies/bookworm/apt.list
@@ -1,0 +1,14 @@
+curl
+ghostscript
+git
+make
+python3-pip
+python-is-python3
+texlive
+texlive-bibtex-extra
+texlive-font-utils
+texlive-fonts-extra
+texlive-latex-extra
+texlive-plain-generic
+unzip
+zip

--- a/.ci/build/make/dependencies/bookworm/python.list
+++ b/.ci/build/make/dependencies/bookworm/python.list
@@ -1,0 +1,1 @@
+../python.list

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -17,6 +17,7 @@ jobs:
         os:
           - debian:buster  # TeX Live 2018
           - debian:bullseye  # TeX Live 2020
+          - debian:bookworm  # TeX Live 2022
     steps:
       - name: Install lsb_release
         run: |
@@ -40,7 +41,7 @@ jobs:
       - name: make
         run: make --jobs=$(nproc) --output-sync
       - name: Archive artifacts
-        if: ${{ matrix.os == 'debian:bullseye' }}
+        if: ${{ matrix.os == 'debian:bookworm' }}
         uses: actions/upload-artifact@v4
         with:
           name: packages


### PR DESCRIPTION
This change adds Debian 12 ("Bookworm") to the containers used by the make job in the build workflow.