### PR TITLE
Install pygments using apt

### DIFF
--- a/.ci/build/make/dependencies/bullseye/apt.list
+++ b/.ci/build/make/dependencies/bullseye/apt.list
@@ -2,8 +2,8 @@ curl
 ghostscript
 git
 make
-python3-pip
 python-is-python3
+python3-pygments
 texlive
 texlive-bibtex-extra
 texlive-font-utils

--- a/.ci/build/make/dependencies/bullseye/python.list
+++ b/.ci/build/make/dependencies/bullseye/python.list
@@ -1,1 +1,0 @@
-../python.list

--- a/.ci/build/make/dependencies/buster/apt.list
+++ b/.ci/build/make/dependencies/buster/apt.list
@@ -2,7 +2,7 @@ curl
 ghostscript
 git
 make
-python3-pip
+python3-pygments python3-pkg-resources
 texlive
 texlive-font-utils
 texlive-fonts-extra

--- a/.ci/build/make/dependencies/buster/python.list
+++ b/.ci/build/make/dependencies/buster/python.list
@@ -1,1 +1,0 @@
-../python.list

--- a/.ci/build/make/dependencies/python.list
+++ b/.ci/build/make/dependencies/python.list
@@ -1,1 +1,0 @@
-pygments

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -35,8 +35,6 @@ jobs:
         run: |
           apt update && apt install --no-install-recommends --yes \
               $(cat .ci/build/make/dependencies/$(lsb_release -cs)/apt.list)
-          pip3 install --requirement \
-              .ci/build/make/dependencies/$(lsb_release -cs)/python.list
       - name: make
         run: make --jobs=$(nproc) --output-sync
       - name: Archive artifacts


### PR DESCRIPTION
This change avoids installing Python packages using `pip`, relying instead on Debian's package manager to prevent future issues with externally-managed environments (see PEP 668 for details).

PEP 668: https://peps.python.org/pep-0668/