### PR TITLE
minted-doc: Do not patch \inputminted for minted 3

### DIFF
--- a/minted-doc/minted-doc.dtx
+++ b/minted-doc/minted-doc.dtx
@@ -108,8 +108,8 @@
 % Identify package and version.
 %    \begin{macrocode}
 \ProvidesPackage{minted-doc}[%
-    2022/06/29 %
-    v0.1.2 %
+    2025/04/03 %
+    v0.1.3 %
     Patches when using minted with docstrip%
 ]
 %    \end{macrocode}
@@ -123,9 +123,9 @@
 %    \end{macrocode}
 %
 % \subsection{Configuration}
-% Check if the \textsf{minted} package is loaded.
+% Check if the version of the \textsf{minted} package is earlier than v3.0.
 %    \begin{macrocode}
-\@ifpackageloaded{minted}{%
+\@ifpackagelater{minted}{2024/10/22}{}{%
 %    \end{macrocode}
 % |\inputminted| implicitly indents the subsequent line even if there is no paragraph break (i.e., an intervening blank line).
 % Do not indent \emph{unless} there is a paragraph break.
@@ -136,10 +136,13 @@
   }{}{}%
 %    \end{macrocode}
 %    \begin{macrocode}
-}{}
+}
 %    \end{macrocode}
 % \changes{0.1.1}{2017/07/13}{%
 %   Do not indent after \textbackslash inputminted
+% }
+% \changes{0.1.3}{2025/04/03}{%
+%   Do not patch \textbackslash inputminted for minted v3.0 (and later)
 % }
 %
 % Check if the version of the \textsf{minted} package is earlier than v2.5.


### PR DESCRIPTION
minted version 3 is a complete rewrite, and the patch to correct indentation after \inputminted is incompatible with the new implementation, leading to the following error message:

    ! Missing \endcsname inserted.
    <to be read again>
                       \noindent

This change only patches the macro for minted version 2.9 and earlier.