### PR TITLE
Update .gitignore for minted version 3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,7 +27,8 @@
 *.toc
 
 *.synctex.gz
-_minted-*
+_minted/
+_minted-*/
 
 .version.tex
 


### PR DESCRIPTION
minted version 3 uses the same cache directory (`_minted`) for all documents. This change updates the Git ignore patterns to exclude that directory.

The existing pattern is NOT removed because document-specific caching can be enabled using the `cachedir` package option.