### PR TITLE
Update Debian versions in CI workflows

### DIFF
--- a/.ci/build/make/dependencies/trixie/apt.list
+++ b/.ci/build/make/dependencies/trixie/apt.list
@@ -2,11 +2,13 @@ curl
 ghostscript
 git
 make
-python3-pygments python3-pkg-resources
+python-is-python3
+python3-pygments
 texlive
+texlive-bibtex-extra
 texlive-font-utils
 texlive-fonts-extra
-texlive-generic-extra
 texlive-latex-extra
+texlive-plain-generic
 unzip
 zip

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,9 +15,9 @@ jobs:
       fail-fast: false
       matrix:
         os:
-          - buster  # TeX Live 2018
           - bullseye  # TeX Live 2020
           - bookworm  # TeX Live 2022
+          - trixie  # TeX Live 2025
     steps:
       - name: Install Git
         run: |


### PR DESCRIPTION
This change replaces Debian 10 ("Buster") with Debian 13 ("Trixie") in the build CI workflow because Debian 10 is no longer supported.